### PR TITLE
Fix #111 The component is vulnerable due to insufficient input sanitization of $tab['icon'] and $tab['color'] before returning it to the browser.

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -691,10 +691,15 @@ function tabs_arconix_shortcode( $atts, $content = null ) {
 
     $GLOBALS['tab_count'] = 0;
     $tabid = 0;
+    $r     = '';
+
+    if( ! isset( $GLOBALS['tabs'] ) ) {
+        $GLOBALS['tabs'] = array();
+    }
 
     do_shortcode( $content );
 
-    if( is_array( $GLOBALS['tabs'] ) ) {
+    if( is_array( $GLOBALS['tabs'] ) && ! empty( $GLOBALS['tabs'] ) ) {
         foreach( $GLOBALS['tabs'] as $tab ) {
 
             // Set up tabid based on the id defined above
@@ -709,7 +714,7 @@ function tabs_arconix_shortcode( $atts, $content = null ) {
                     break;
             }
 
-            $tabs[] = '<li data-arconix-icon="' . $tab['icon'] . '" data-arconix-color="' . $tab['color'] . '" class="arconix-tab tab-' . sanitize_html_class( $tab['title'] ) . '"><a class="" href="#tab-' . $tabid . '">' . esc_html( $tab['title'] ) . '</a></li>';
+            $tabs[] = '<li data-arconix-icon="' . esc_attr( $tab['icon'] ) . '" data-arconix-color="' . esc_attr( $tab['color'] ) . '" class="arconix-tab tab-' . sanitize_html_class( $tab['title'] ) . '"><a class="" href="#tab-' . $tabid . '">' . esc_html( $tab['title'] ) . '</a></li>';
             $panes[] = '<div class="arconix-pane pane-' . sanitize_html_class( $tab['title'] ) . '">' . remove_wpautop( $tab['content'] ) . '</div>';
         }
         $r = "\n" . '<div class="arconix-tabs-' . sanitize_html_class( $style ) . $css . '"><ul class="arconix-tabs">' . implode( "\n", $tabs ) . '</ul>' . "\n" . '<div class="arconix-panes">' . implode( "\n", $panes ) . '</div></div>' . "\n";


### PR DESCRIPTION
Fix #111 The component is vulnerable due to insufficient input sanitization of $tab['icon'] and $tab['color'] before returning it to the browser.

Cause: $tab['icon'] and $tab['color'] attributes were concatenated directly into HTML output without escaping, allowing Contributor+ users to inject arbitrary HTML/JS via shortcode attributes (stored XSS).

Fix: Wrapped both values in esc_attr() before output, consistent with how title is already escaped via esc_html().