### PR TITLE
Fix #113 Undefined global variable $tab_count in tab shortcode.

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -760,6 +760,13 @@ function tab_arconix_shortcode( $atts, $content = null ) {
         ) );
     extract( shortcode_atts( $defaults, $atts, 'arconix_tab' ) );
 
+    if ( ! isset( $GLOBALS['tab_count'] ) ) {
+        $GLOBALS['tab_count'] = 0;
+    }
+    if ( ! isset( $GLOBALS['tabs'] ) ) {
+        $GLOBALS['tabs'] = array();
+    }
+
     $x = $GLOBALS['tab_count'];
     $GLOBALS['tabs'][$x] = array( 'title' => sprintf( $title, $GLOBALS['tab_count'] ), 'content' => $content, 'icon' => $icon, 'color' => $icon_color );
 


### PR DESCRIPTION
Fix #113 Undefined global variable $tab_count in tab shortocde.

Cause: PHP 8.1+ warnings caused by accessing uninitialized global variables ($tab_count and $tabs) in the tab shortcode.

Fix: Initialize the required global variables before accessing them to prevent undefined global variable warnings during shortcode execution.