### PR TITLE
Fix #116 vulnerable to Cross Site Scripting (XSS) issue.

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:disable
 /**
  * Returns an array of shortcodes that have passed through a compatibility mode check
  *
@@ -294,7 +295,7 @@ function accordions_arconix_shortcode( $atts, $content = null ) {
     // Combine safely.
     $class_string = esc_attr( "arconix-accordions arconix-accordions-{$type} arconix-accordions-{$load}{$css}" );
 
-    $r = '<div class="' . $class_string . '">' . remove_wpautop( $content ) . '</div>';
+    $r = '<div class="' . $class_string . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     return apply_filters( 'arconix_accordions_return', $r );
 }
@@ -331,7 +332,7 @@ function accordion_arconix_shortcode( $atts, $content = null ) {
     $icon = '<i class="fa"></i>';
 
     $r = '<div class="arconix-accordion-title accordion-' . sanitize_html_class( $title ) . $last . '">' . $icon .'<p>'.esc_html( $title ) . '</p></div>';
-    $r .= '<div class="arconix-accordion-content' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $r .= '<div class="arconix-accordion-content' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     return apply_filters( 'arconix_accordions_return', $r );
 }
@@ -641,7 +642,7 @@ function list_arconix_shortcode( $atts, $content = null ) {
             break;
 }
 
-    $r = '<div class="arconix-list" data-arconix-icon="' . esc_attr( $icon ) . '" data-arconix-color="' . esc_attr( $icon_color ) . '">' . remove_wpautop( $content ) . '</div>';
+    $r = '<div class="arconix-list" data-arconix-icon="' . esc_attr( $icon ) . '" data-arconix-color="' . esc_attr( $icon_color ) . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     return apply_filters( 'arconix_list_return', $r );
 }
@@ -715,7 +716,7 @@ function tabs_arconix_shortcode( $atts, $content = null ) {
             }
 
             $tabs[] = '<li data-arconix-icon="' . esc_attr( $tab['icon'] ) . '" data-arconix-color="' . esc_attr( $tab['color'] ) . '" class="arconix-tab tab-' . sanitize_html_class( $tab['title'] ) . '"><a class="" href="#tab-' . $tabid . '">' . esc_html( $tab['title'] ) . '</a></li>';
-            $panes[] = '<div class="arconix-pane pane-' . sanitize_html_class( $tab['title'] ) . '">' . remove_wpautop( $tab['content'] ) . '</div>';
+            $panes[] = '<div class="arconix-pane pane-' . sanitize_html_class( $tab['title'] ) . '">' . wp_kses_post( remove_wpautop( $tab['content'] ) ) . '</div>';
         }
         $r = "\n" . '<div class="arconix-tabs-' . sanitize_html_class( $style ) . $css . '"><ul class="arconix-tabs">' . implode( "\n", $tabs ) . '</ul>' . "\n" . '<div class="arconix-panes">' . implode( "\n", $panes ) . '</div></div>' . "\n";
     }
@@ -820,7 +821,7 @@ function toggle_arconix_shortcode( $atts, $content = null ) {
     $icon = "<i class='fa {$i}'></i>";
 
     $r = '<div class="arconix-toggle-wrap'. $css . '">' . '<div class="arconix-toggle-title ' . $load . '">' . $icon . esc_html( $title ) . '</div>';
-    $r .= '<div class="arconix-toggle-content">' . remove_wpautop( $content ) . '</div></div>';
+    $r .= '<div class="arconix-toggle-content">' . wp_kses_post( remove_wpautop( $content ) ) . '</div></div>';
 
     return apply_filters( 'arconix_toggle_return', $r );
 }
@@ -847,7 +848,7 @@ function one_half_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-one-half' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-one-half' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -877,7 +878,7 @@ function one_third_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-one-third' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-one-third' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -907,7 +908,7 @@ function two_thirds_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-two-thirds' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-two-thirds' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -937,7 +938,7 @@ function one_fourth_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-one-fourth' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-one-fourth' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -967,7 +968,7 @@ function two_fourths_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-two-fourths' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-two-fourths' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -997,7 +998,7 @@ function three_fourths_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-three-fourths' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-three-fourths' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -1027,7 +1028,7 @@ function one_fifth_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-one-fifth' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-one-fifth' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -1057,7 +1058,7 @@ function two_fifths_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-two-fifths' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-two-fifths' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -1087,7 +1088,7 @@ function three_fifths_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-three-fifths' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-three-fifths' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;
@@ -1117,7 +1118,7 @@ function four_fifths_arconix_shortcode( $atts, $content = null ) {
 
     $last ? $last = ' arconix-column-last' : $last = '';
 
-    $return = '<div class="arconix-column-four-fifths' . $last . '">' . remove_wpautop( $content ) . '</div>';
+    $return = '<div class="arconix-column-four-fifths' . $last . '">' . wp_kses_post( remove_wpautop( $content ) ) . '</div>';
 
     $float = clearfloat( $last );
     $return .= $float;


### PR DESCRIPTION
Fix #116 Sanitize shortcode content output to prevent stored XSS (CVSS 6.5)

Cause: remove_wpautop($content) returned raw, unescaped user-supplied
shortcode content across 13 shortcodes (toggle, accordion, tabs, list,
columns), allowing injected HTML/JS (e.g. <img onerror=...>) to execute
on page render.

Fix: Wrap all remove_wpautop($content) calls with wp_kses_post() to
strip dangerous tags/attributes while preserving safe HTML formatting,
matching the pattern already used in the box shortcode.

**For replicate** - 
`[toggle title="t"]<img src=x onerror=alert(1)>[/toggle]`
check alert is coming with the live copy.
